### PR TITLE
Actualizar cassandra-driver a versión 3.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup
 
-VERSION = '0.3.14'
+VERSION = '0.3.15'
 
 install_requires = [
     "arrow==1.*",
-    "cassandra-driver==3.28.0",
+    "cassandra-driver>=3.29.0",
     "click==8.1.3",
     "future==0.18.3",
     "python-dateutil==2.8.*",


### PR DESCRIPTION
El driver de conexión a cassandra tiene una nueva versión que ademas añade soporte a versiones de python mayores que 3.8, así que toca actualizar y despues actualizaré todos los demas servicios.